### PR TITLE
Make build should use vendor directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ lint:
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=mod -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o ${GOPATH}/bin/${EXE_DRIVER_NAME} ./cmd/
+	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=vendor -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o ${GOPATH}/bin/${EXE_DRIVER_NAME} ./cmd/
 
 .PHONY: verify
 verify:


### PR DESCRIPTION
This pulls in the the fix for this upstream PR:
https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/pull/45
Upstream comparision: https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/compare/master...dobsonj:build-using-vendor-dir-merge
/cc @openshift/storage 