### PR TITLE
OCPBUGS-416: Add udev

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -5,7 +5,7 @@ RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.11:base
 COPY --from=builder /go/bin/ibm-vpc-block-csi-driver /bin/ibm-vpc-block-csi-driver
-RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates && yum clean all && rm -rf /var/cache/yum
+RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates udev && yum clean all && rm -rf /var/cache/yum
 
 LABEL description="IBM VPC Block CSI Driver"
 


### PR DESCRIPTION
The CSI driver needs to call "udevadm trigger" to refresh devices. Udev socket and rules are projected into the CSI driver container via hostPath volumes, so udevadm should do the scanning on the host.

@openshift/storage 