### PR TITLE
UPSTREAM: 98: Reformat code with go 1.19 again

### DIFF
--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -503,7 +503,7 @@ func (c *fakeProviderSession) ListSnapshots() ([]*provider.Snapshot, error) {
 	return nil, nil
 }
 
-//List all the  snapshots for a given volume
+// List all the  snapshots for a given volume
 func (c *fakeProviderSession) ListAllSnapshots(volumeID string) ([]*provider.Snapshot, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Upstream PR #98 is not enough, we have an older version in OCP and more files need to be reformatted.

@openshift/storage 