### PR TITLE
UPSTREAM: 93: bump golint for go 1.18

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.17-openshift-4.11
+  tag: rhel-8-release-golang-1.18-openshift-4.11

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
 WORKDIR /go/src/github.com/openshift/ibm-vpc-block-csi-driver
 COPY . .
 RUN make build

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 
 if [[ -z "$(command -v golangci-lint)" ]]; then
   echo "Cannot find golangci-lint. Installing golangci-lint..."
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
   export PATH=$PATH:$(go env GOPATH)/bin
 fi
 

--- a/pkg/ibmcsidriver/node.go
+++ b/pkg/ibmcsidriver/node.go
@@ -395,7 +395,7 @@ func (csiNS *CSINodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.Nod
 	ctxLogger, requestID := utils.GetContextLogger(ctx, false)
 	ctxLogger.Info("CSINodeServer-NodeGetVolumeStats... ", zap.Reflect("Request", *req)) //nolint:staticcheck
 	metrics.UpdateDurationFromStart(ctxLogger, "NodeGetVolumeStats", time.Now())
-	if req == nil || req.VolumeId == "" {
+	if req == nil || req.VolumeId == "" { //nolint:staticcheck
 		return nil, commonError.GetCSIError(ctxLogger, commonError.EmptyVolumeID, requestID, nil)
 	}
 


### PR DESCRIPTION
This is only a part of upstream PR #93 that updates golint to be compatible with go 1.18.
And bump go to 1.18, as it's requested by ART in https://github.com/openshift/ibm-vpc-block-csi-driver/pull/15.
