### PR TITLE
OCPBUGS-12325: UPSTREAM: 118: Update golangci-lint

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -16,6 +16,7 @@
 
 set -euo pipefail
 
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 if [[ -z "$(command -v golangci-lint)" ]]; then
   echo "Cannot find golangci-lint. Installing golangci-lint..."
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0


### PR DESCRIPTION
To support go 1.20. This is only a very small part of upstream PR #118 - it updates kube deps and whatnot.

@openshift/storage 