### PR TITLE
OCPBUGS-18105: [IBM VPC] failed provisioning volume in proxy cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/IBM/ibm-csi-common v1.1.7
-	github.com/IBM/ibmcloud-volume-interface v1.1.4
+	github.com/IBM/ibmcloud-volume-interface v1.2.0
 	github.com/IBM/ibmcloud-volume-vpc v1.1.5
 	github.com/IBM/secret-utils-lib v1.1.4
 	github.com/container-storage-interface/spec v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/IBM/go-sdk-core/v5 v5.9.1 h1:06pXbD9Rgmqqe2HA5YAeQbB4eYRRFgIoOT+Kh3cp
 github.com/IBM/go-sdk-core/v5 v5.9.1/go.mod h1:axE2JrRq79gIJTjKPBwV6gWHswvVptBjbcvvCPIxARM=
 github.com/IBM/ibm-csi-common v1.1.7 h1:4QY86ZJ8rX1ghrhytgIY+VoEemeG+J2PbvzXTuYZakc=
 github.com/IBM/ibm-csi-common v1.1.7/go.mod h1:TilE1H+F4rzhgnEHHDzdcJ9M+WcJB6QCBxwtGdCDv7A=
-github.com/IBM/ibmcloud-volume-interface v1.1.4 h1:rEKAs0rASZTpKWjGPh19GDozpD7Agc21Jjyewo/14/Q=
-github.com/IBM/ibmcloud-volume-interface v1.1.4/go.mod h1:I1ZVCvnk+NSNhncg2G06mw5X+jf5XyUP87sT6x1aLVo=
+github.com/IBM/ibmcloud-volume-interface v1.2.0 h1:9SqCaC0H6nhiXZL57FsR0n1B7rQ7CVW86kjVKqGmMck=
+github.com/IBM/ibmcloud-volume-interface v1.2.0/go.mod h1:646HOeq8dAKbgpr7jRehGKckhgduJyII2uN5T6RDLww=
 github.com/IBM/ibmcloud-volume-vpc v1.1.5 h1:dN/LxVxtkiK0g4JzDP2VnHoh+LfHwPyzB+TgUZbhVyU=
 github.com/IBM/ibmcloud-volume-vpc v1.1.5/go.mod h1:+UTHGrGzjyA2VjaozhB1xOjAcJ1lsi9mFqfGsqmuCOQ=
 github.com/IBM/secret-common-lib v1.1.4 h1:gKpKnaP45Y6u7VpSlFfXjjTAHpu4bz9Ofy+aR0t2RcI=

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/config/config.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/config/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	API       *APIConfig
 }
 
-//ReadConfig loads the config from k8s secret ...
+// ReadConfig loads the config from k8s secret ...
 func ReadConfig(k8sClient k8s_utils.KubernetesClient, logger *zap.Logger) (*Config, error) {
 	data, err := k8s_utils.GetSecretData(k8sClient, utils.STORAGE_SECRET_STORE_SECRET, utils.SECRET_STORE_FILE)
 	if err != nil {
@@ -153,7 +153,7 @@ type VPCProviderConfig struct {
 	ClusterVolumeLabel string
 }
 
-//IKSConfig config
+// IKSConfig config
 type IKSConfig struct {
 	Enabled              bool   `toml:"iks_enabled" envconfig:"IKS_ENABLED"`
 	IKSBlockProviderName string `toml:"iks_block_provider_name" envconfig:"IKS_BLOCK_PROVIDER_NAME"`

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/config/tls.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/config/tls.go
@@ -25,21 +25,11 @@ import (
 
 // GeneralCAHttpClient returns an http.Client configured for general use
 func GeneralCAHttpClient() (*http.Client, error) {
-	httpClient := &http.Client{
-
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12, // Require TLS 1.2 or higher
-			},
-		},
-
-		// softlayer.go has been overriding http.DefaultClient and forcing 120s
-		// timeout on us, so we'll continue to force it on ourselves in case
-		// we've accidentally become acustomed to it.
-		Timeout: time.Second * 120,
-	}
-
-	return httpClient, nil
+	// softlayer.go has been overriding http.DefaultClient and forcing 120s
+	// timeout on us, so we'll continue to force it on ourselves in case
+	// we've accidentally become acustomed to it.
+	timeout := time.Second * 120
+	return GeneralCAHttpClientWithTimeout(timeout)
 }
 
 // GeneralCAHttpClientWithTimeout returns an http.Client configured for general use
@@ -47,6 +37,7 @@ func GeneralCAHttpClientWithTimeout(timeout time.Duration) (*http.Client, error)
 	httpClient := &http.Client{
 
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				MinVersion: tls.VersionTLS12, // Require TLS 1.2 or higher
 			},

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/constants.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/constants.go
@@ -17,7 +17,7 @@
 // Package provider ...
 package provider
 
-//RequestIDType ... Context won't allow keys as "string" type
+// RequestIDType ... Context won't allow keys as "string" type
 type RequestIDType string
 
 const (

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/contexts.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/contexts.go
@@ -18,6 +18,7 @@
 package provider
 
 // Context represents the volume provider management API for individual account, user ID, etc.
+//
 //go:generate counterfeiter -o fakes/context.go --fake-name Context . Context
 type Context interface {
 	VolumeManager
@@ -27,6 +28,7 @@ type Context interface {
 }
 
 // Session is an Context that is notified when it is no longer required
+//
 //go:generate counterfeiter -o fake/fake_session.go --fake-name FakeSession . Session
 type Session interface {
 	Context

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/default_volume_provider.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/default_volume_provider.go
@@ -19,49 +19,49 @@ package provider
 
 import "net/http"
 
-//DefaultVolumeProvider Implementation
+// DefaultVolumeProvider Implementation
 type DefaultVolumeProvider struct {
 	sess *Session
 }
 
 var _ Session = &DefaultVolumeProvider{sess: nil}
 
-//ProviderName returns provider
+// ProviderName returns provider
 func (volprov *DefaultVolumeProvider) ProviderName() VolumeProvider {
 	return VolumeProvider("")
 }
 
-//Type returns the underlying volume type
+// Type returns the underlying volume type
 func (volprov *DefaultVolumeProvider) Type() VolumeType {
 	return ""
 }
 
-//CreateVolume creates a volume
+// CreateVolume creates a volume
 func (volprov *DefaultVolumeProvider) CreateVolume(VolumeRequest Volume) (*Volume, error) {
 	return nil, nil
 }
 
-//AttachVolume attaches a volume
+// AttachVolume attaches a volume
 func (volprov *DefaultVolumeProvider) AttachVolume(attachRequest VolumeAttachmentRequest) (*VolumeAttachmentResponse, error) {
 	return nil, nil
 }
 
-//CreateVolumeFromSnapshot creates a volume from snapshot
+// CreateVolumeFromSnapshot creates a volume from snapshot
 func (volprov *DefaultVolumeProvider) CreateVolumeFromSnapshot(snapshot Snapshot, tags map[string]string) (*Volume, error) {
 	return nil, nil
 }
 
-//UpdateVolume the volume
+// UpdateVolume the volume
 func (volprov *DefaultVolumeProvider) UpdateVolume(Volume) error {
 	return nil
 }
 
-//DeleteVolume deletes the volume
+// DeleteVolume deletes the volume
 func (volprov *DefaultVolumeProvider) DeleteVolume(*Volume) error {
 	return nil
 }
 
-//GetVolume by using ID
+// GetVolume by using ID
 func (volprov *DefaultVolumeProvider) GetVolume(id string) (*Volume, error) {
 	return nil, nil
 }
@@ -73,7 +73,7 @@ func (volprov *DefaultVolumeProvider) GetVolumeByName(name string) (*Volume, err
 	return nil, nil
 }
 
-//ListVolumes Get volume lists by using filters
+// ListVolumes Get volume lists by using filters
 func (volprov *DefaultVolumeProvider) ListVolumes(limit int, start string, tags map[string]string) (*VolumeList, error) {
 	return nil, nil
 }
@@ -85,7 +85,7 @@ func (volprov *DefaultVolumeProvider) GetVolumeByRequestID(requestID string) (*V
 	return nil, nil
 }
 
-//AuthorizeVolume allows aceess to volume  based on given authorization
+// AuthorizeVolume allows aceess to volume  based on given authorization
 func (volprov *DefaultVolumeProvider) AuthorizeVolume(volumeAuthorization VolumeAuthorization) error {
 	return nil
 }
@@ -95,24 +95,24 @@ func (volprov *DefaultVolumeProvider) DetachVolume(detachRequest VolumeAttachmen
 	return nil, nil
 }
 
-//WaitForAttachVolume waits for the volume to be attached to the host
-//Return error if wait is timed out OR there is other error
+// WaitForAttachVolume waits for the volume to be attached to the host
+// Return error if wait is timed out OR there is other error
 func (volprov *DefaultVolumeProvider) WaitForAttachVolume(attachRequest VolumeAttachmentRequest) (*VolumeAttachmentResponse, error) {
 	return nil, nil
 }
 
-//WaitForDetachVolume waits for the volume to be detached from the host
-//Return error if wait is timed out OR there is other error
+// WaitForDetachVolume waits for the volume to be detached from the host
+// Return error if wait is timed out OR there is other error
 func (volprov *DefaultVolumeProvider) WaitForDetachVolume(detachRequest VolumeAttachmentRequest) error {
 	return nil
 }
 
-//GetVolumeAttachment retirves the current status of given volume attach request
+// GetVolumeAttachment retirves the current status of given volume attach request
 func (volprov *DefaultVolumeProvider) GetVolumeAttachment(attachRequest VolumeAttachmentRequest) (*VolumeAttachmentResponse, error) {
 	return nil, nil
 }
 
-//OrderSnapshot orders the snapshot
+// OrderSnapshot orders the snapshot
 func (volprov *DefaultVolumeProvider) OrderSnapshot(VolumeRequest Volume) error {
 	return nil
 }
@@ -122,63 +122,73 @@ func (volprov *DefaultVolumeProvider) CreateSnapshot(sourceVolumeID string, snap
 	return nil, nil
 }
 
-//DeleteSnapshot deletes the snapshot
+// DeleteSnapshot deletes the snapshot
 func (volprov *DefaultVolumeProvider) DeleteSnapshot(*Snapshot) error {
 	return nil
 }
 
-//GetSnapshot gets the snapshot
+// GetSnapshot gets the snapshot
 func (volprov *DefaultVolumeProvider) GetSnapshot(snapshotID string) (*Snapshot, error) {
 	return nil, nil
 }
 
-//GetSnapshotByName gets the snapshot
+// GetSnapshotByName gets the snapshot
 func (volprov *DefaultVolumeProvider) GetSnapshotByName(snapshotName string) (*Snapshot, error) {
 	return nil, nil
 }
 
-//ListSnapshots list the snapshots
+// ListSnapshots list the snapshots
 func (volprov *DefaultVolumeProvider) ListSnapshots(limit int, start string, tags map[string]string) (*SnapshotList, error) {
 	return nil, nil
 }
 
-//ExpandVolume expand the volume with authorization by passing required information in the volume object
+// ExpandVolume expand the volume with authorization by passing required information in the volume object
 func (volprov *DefaultVolumeProvider) ExpandVolume(expandVolumeRequest ExpandVolumeRequest) (int64, error) {
 	return 0, nil
 }
 
-//GetProviderDisplayName gets provider by displayname
+// GetProviderDisplayName gets provider by displayname
 func (volprov *DefaultVolumeProvider) GetProviderDisplayName() VolumeProvider {
 	return ""
 }
 
-//Close is called when the Session is nolonger required
+// Close is called when the Session is nolonger required
 func (volprov *DefaultVolumeProvider) Close() {
 }
 
-//CreateVolumeAccessPoint to create access point
+// CreateVolumeAccessPoint to create access point
 func (volprov *DefaultVolumeProvider) CreateVolumeAccessPoint(accessPointRequest VolumeAccessPointRequest) (*VolumeAccessPointResponse, error) {
 	return nil, nil
 }
 
-//DeleteVolumeAccessPoint method delete a access point
+// DeleteVolumeAccessPoint method delete a access point
 func (volprov *DefaultVolumeProvider) DeleteVolumeAccessPoint(deleteAccessPointRequest VolumeAccessPointRequest) (*http.Response, error) {
 	return nil, nil
 }
 
-//WaitForCreateVolumeAccessPoint waits for the volume access point to be created
-//Return error if wait is timed out OR there is other error
+// WaitForCreateVolumeAccessPoint waits for the volume access point to be created
+// Return error if wait is timed out OR there is other error
 func (volprov *DefaultVolumeProvider) WaitForCreateVolumeAccessPoint(accessPointRequest VolumeAccessPointRequest) (*VolumeAccessPointResponse, error) {
 	return nil, nil
 }
 
-//WaitForDeleteVolumeAccessPoint waits for the volume access point to be deleted
-//Return error if wait is timed out OR there is other error
+// WaitForDeleteVolumeAccessPoint waits for the volume access point to be deleted
+// Return error if wait is timed out OR there is other error
 func (volprov *DefaultVolumeProvider) WaitForDeleteVolumeAccessPoint(deleteAccessPointRequest VolumeAccessPointRequest) error {
 	return nil
 }
 
-//GetVolumeAccessPoint retrieves the current status of given volume AccessPoint request
+// GetVolumeAccessPoint retrieves the current status of given volume AccessPoint request
 func (volprov *DefaultVolumeProvider) GetVolumeAccessPoint(accessPointRequest VolumeAccessPointRequest) (*VolumeAccessPointResponse, error) {
 	return nil, nil
+}
+
+// GetSubnetForVolumeAccessPoint retrieves the subnetId matching with available subnets in the zone
+func (volprov *DefaultVolumeProvider) GetSubnetForVolumeAccessPoint(subnetRequest SubnetRequest) (string, error) {
+	return "", nil
+}
+
+// GetSecurityGroupForVolumeAccessPoint retrieves the securityGroup matching with available cluster SG in the VPC
+func (volprov *DefaultVolumeProvider) GetSecurityGroupForVolumeAccessPoint(securityGroupRequest SecurityGroupRequest) (string, error) {
+	return "", nil
 }

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/fake/fake_session.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/fake/fake_session.go
@@ -162,6 +162,19 @@ type FakeSession struct {
 	getProviderDisplayNameReturnsOnCall map[int]struct {
 		result1 provider.VolumeProvider
 	}
+	GetSecurityGroupForVolumeAccessPointStub        func(provider.SecurityGroupRequest) (string, error)
+	getSecurityGroupForVolumeAccessPointMutex       sync.RWMutex
+	getSecurityGroupForVolumeAccessPointArgsForCall []struct {
+		arg1 provider.SecurityGroupRequest
+	}
+	getSecurityGroupForVolumeAccessPointReturns struct {
+		result1 string
+		result2 error
+	}
+	getSecurityGroupForVolumeAccessPointReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	GetSnapshotStub        func(string) (*provider.Snapshot, error)
 	getSnapshotMutex       sync.RWMutex
 	getSnapshotArgsForCall []struct {
@@ -186,6 +199,19 @@ type FakeSession struct {
 	}
 	getSnapshotByNameReturnsOnCall map[int]struct {
 		result1 *provider.Snapshot
+		result2 error
+	}
+	GetSubnetForVolumeAccessPointStub        func(provider.SubnetRequest) (string, error)
+	getSubnetForVolumeAccessPointMutex       sync.RWMutex
+	getSubnetForVolumeAccessPointArgsForCall []struct {
+		arg1 provider.SubnetRequest
+	}
+	getSubnetForVolumeAccessPointReturns struct {
+		result1 string
+		result2 error
+	}
+	getSubnetForVolumeAccessPointReturnsOnCall map[int]struct {
+		result1 string
 		result2 error
 	}
 	GetVolumeStub        func(string) (*provider.Volume, error)
@@ -1140,6 +1166,70 @@ func (fake *FakeSession) GetProviderDisplayNameReturnsOnCall(i int, result1 prov
 	}{result1}
 }
 
+func (fake *FakeSession) GetSecurityGroupForVolumeAccessPoint(arg1 provider.SecurityGroupRequest) (string, error) {
+	fake.getSecurityGroupForVolumeAccessPointMutex.Lock()
+	ret, specificReturn := fake.getSecurityGroupForVolumeAccessPointReturnsOnCall[len(fake.getSecurityGroupForVolumeAccessPointArgsForCall)]
+	fake.getSecurityGroupForVolumeAccessPointArgsForCall = append(fake.getSecurityGroupForVolumeAccessPointArgsForCall, struct {
+		arg1 provider.SecurityGroupRequest
+	}{arg1})
+	stub := fake.GetSecurityGroupForVolumeAccessPointStub
+	fakeReturns := fake.getSecurityGroupForVolumeAccessPointReturns
+	fake.recordInvocation("GetSecurityGroupForVolumeAccessPoint", []interface{}{arg1})
+	fake.getSecurityGroupForVolumeAccessPointMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSession) GetSecurityGroupForVolumeAccessPointCallCount() int {
+	fake.getSecurityGroupForVolumeAccessPointMutex.RLock()
+	defer fake.getSecurityGroupForVolumeAccessPointMutex.RUnlock()
+	return len(fake.getSecurityGroupForVolumeAccessPointArgsForCall)
+}
+
+func (fake *FakeSession) GetSecurityGroupForVolumeAccessPointCalls(stub func(provider.SecurityGroupRequest) (string, error)) {
+	fake.getSecurityGroupForVolumeAccessPointMutex.Lock()
+	defer fake.getSecurityGroupForVolumeAccessPointMutex.Unlock()
+	fake.GetSecurityGroupForVolumeAccessPointStub = stub
+}
+
+func (fake *FakeSession) GetSecurityGroupForVolumeAccessPointArgsForCall(i int) provider.SecurityGroupRequest {
+	fake.getSecurityGroupForVolumeAccessPointMutex.RLock()
+	defer fake.getSecurityGroupForVolumeAccessPointMutex.RUnlock()
+	argsForCall := fake.getSecurityGroupForVolumeAccessPointArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeSession) GetSecurityGroupForVolumeAccessPointReturns(result1 string, result2 error) {
+	fake.getSecurityGroupForVolumeAccessPointMutex.Lock()
+	defer fake.getSecurityGroupForVolumeAccessPointMutex.Unlock()
+	fake.GetSecurityGroupForVolumeAccessPointStub = nil
+	fake.getSecurityGroupForVolumeAccessPointReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSession) GetSecurityGroupForVolumeAccessPointReturnsOnCall(i int, result1 string, result2 error) {
+	fake.getSecurityGroupForVolumeAccessPointMutex.Lock()
+	defer fake.getSecurityGroupForVolumeAccessPointMutex.Unlock()
+	fake.GetSecurityGroupForVolumeAccessPointStub = nil
+	if fake.getSecurityGroupForVolumeAccessPointReturnsOnCall == nil {
+		fake.getSecurityGroupForVolumeAccessPointReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.getSecurityGroupForVolumeAccessPointReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeSession) GetSnapshot(arg1 string) (*provider.Snapshot, error) {
 	fake.getSnapshotMutex.Lock()
 	ret, specificReturn := fake.getSnapshotReturnsOnCall[len(fake.getSnapshotArgsForCall)]
@@ -1264,6 +1354,70 @@ func (fake *FakeSession) GetSnapshotByNameReturnsOnCall(i int, result1 *provider
 	}
 	fake.getSnapshotByNameReturnsOnCall[i] = struct {
 		result1 *provider.Snapshot
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSession) GetSubnetForVolumeAccessPoint(arg1 provider.SubnetRequest) (string, error) {
+	fake.getSubnetForVolumeAccessPointMutex.Lock()
+	ret, specificReturn := fake.getSubnetForVolumeAccessPointReturnsOnCall[len(fake.getSubnetForVolumeAccessPointArgsForCall)]
+	fake.getSubnetForVolumeAccessPointArgsForCall = append(fake.getSubnetForVolumeAccessPointArgsForCall, struct {
+		arg1 provider.SubnetRequest
+	}{arg1})
+	stub := fake.GetSubnetForVolumeAccessPointStub
+	fakeReturns := fake.getSubnetForVolumeAccessPointReturns
+	fake.recordInvocation("GetSubnetForVolumeAccessPoint", []interface{}{arg1})
+	fake.getSubnetForVolumeAccessPointMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSession) GetSubnetForVolumeAccessPointCallCount() int {
+	fake.getSubnetForVolumeAccessPointMutex.RLock()
+	defer fake.getSubnetForVolumeAccessPointMutex.RUnlock()
+	return len(fake.getSubnetForVolumeAccessPointArgsForCall)
+}
+
+func (fake *FakeSession) GetSubnetForVolumeAccessPointCalls(stub func(provider.SubnetRequest) (string, error)) {
+	fake.getSubnetForVolumeAccessPointMutex.Lock()
+	defer fake.getSubnetForVolumeAccessPointMutex.Unlock()
+	fake.GetSubnetForVolumeAccessPointStub = stub
+}
+
+func (fake *FakeSession) GetSubnetForVolumeAccessPointArgsForCall(i int) provider.SubnetRequest {
+	fake.getSubnetForVolumeAccessPointMutex.RLock()
+	defer fake.getSubnetForVolumeAccessPointMutex.RUnlock()
+	argsForCall := fake.getSubnetForVolumeAccessPointArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeSession) GetSubnetForVolumeAccessPointReturns(result1 string, result2 error) {
+	fake.getSubnetForVolumeAccessPointMutex.Lock()
+	defer fake.getSubnetForVolumeAccessPointMutex.Unlock()
+	fake.GetSubnetForVolumeAccessPointStub = nil
+	fake.getSubnetForVolumeAccessPointReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSession) GetSubnetForVolumeAccessPointReturnsOnCall(i int, result1 string, result2 error) {
+	fake.getSubnetForVolumeAccessPointMutex.Lock()
+	defer fake.getSubnetForVolumeAccessPointMutex.Unlock()
+	fake.GetSubnetForVolumeAccessPointStub = nil
+	if fake.getSubnetForVolumeAccessPointReturnsOnCall == nil {
+		fake.getSubnetForVolumeAccessPointReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.getSubnetForVolumeAccessPointReturnsOnCall[i] = struct {
+		result1 string
 		result2 error
 	}{result1, result2}
 }
@@ -2166,10 +2320,14 @@ func (fake *FakeSession) Invocations() map[string][][]interface{} {
 	defer fake.expandVolumeMutex.RUnlock()
 	fake.getProviderDisplayNameMutex.RLock()
 	defer fake.getProviderDisplayNameMutex.RUnlock()
+	fake.getSecurityGroupForVolumeAccessPointMutex.RLock()
+	defer fake.getSecurityGroupForVolumeAccessPointMutex.RUnlock()
 	fake.getSnapshotMutex.RLock()
 	defer fake.getSnapshotMutex.RUnlock()
 	fake.getSnapshotByNameMutex.RLock()
 	defer fake.getSnapshotByNameMutex.RUnlock()
+	fake.getSubnetForVolumeAccessPointMutex.RLock()
+	defer fake.getSubnetForVolumeAccessPointMutex.RUnlock()
 	fake.getVolumeMutex.RLock()
 	defer fake.getVolumeMutex.RUnlock()
 	fake.getVolumeAccessPointMutex.RLock()

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/volume_file_access_point.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/volume_file_access_point.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-//VolumeFileAccessPointManager ...
+// VolumeFileAccessPointManager ...
 type VolumeFileAccessPointManager interface {
 	//CreateVolumeAccessPoint to create a access point
 	CreateVolumeAccessPoint(accessPointRequest VolumeAccessPointRequest) (*VolumeAccessPointResponse, error)
@@ -40,9 +40,15 @@ type VolumeFileAccessPointManager interface {
 
 	//GetVolumeAccessPoint retrieves the current status of given volume AccessPoint request
 	GetVolumeAccessPoint(accessPointRequest VolumeAccessPointRequest) (*VolumeAccessPointResponse, error)
+
+	//GetSubnetForVolumeAccessPoint retrieves the subnet for volume AccessPoint
+	GetSubnetForVolumeAccessPoint(subnetRequest SubnetRequest) (string, error)
+
+	//GetSecurityGroupForVolumeAccessPoint retrieves the securityGroup for volume AccessPoint
+	GetSecurityGroupForVolumeAccessPoint(securityGroupRequest SecurityGroupRequest) (string, error)
 }
 
-//VolumeAccessPointRequest used for both create and delete access point
+// VolumeAccessPointRequest used for both create and delete access point
 type VolumeAccessPointRequest struct {
 
 	//AccessPoint name is optional.
@@ -59,13 +65,57 @@ type VolumeAccessPointRequest struct {
 
 	//VPC to create AccessPoint for
 	VPCID string `json:"vpc_id,omitempty"`
+
+	//AccessControlMode to enable/disable Elastic Network Interface
+	AccessControlMode string `json:"access_control_mode,omitempty"`
+
+	//PrimaryIP
+	PrimaryIP *PrimaryIP `json:"primary_ip,omitempty"`
+
+	//SecurityGroups to be used for ENI
+	SecurityGroups *[]SecurityGroup `json:"security_groups,omitempty"`
+
+	//ResourceGroup for ENI
+	ResourceGroup *ResourceGroup `json:"resource_group,omitempty"`
+
+	//EncryptionInTransit
+	EncryptionInTransit string `json:"transit_encryption,omitempty"`
 }
 
-//VolumeAccessPointResponse used for both delete and create access point
+// VolumeAccessPointResponse used for both delete and create access point
 type VolumeAccessPointResponse struct {
 	VolumeID      string     `json:"volumeID"`
 	AccessPointID string     `json:"AccessPointID"`
 	Status        string     `json:"status"`
 	MountPath     string     `json:"mount_path"`
 	CreatedAt     *time.Time `json:"created_at,omitempty"`
+}
+
+// SubnetRequest used for fetching the subnet for volume access point
+type SubnetRequest struct {
+
+	//SubnetIDList to match the subnetID from available list of subnets.
+	SubnetIDList string `json:"subnet_id_list,omitempty"`
+
+	//Zone to find out the subnet-id for ENI
+	ZoneName string `json:"zone_name,omitempty"`
+
+	//ResourceGroup to find out the subnet-id for ENI
+	ResourceGroup *ResourceGroup `json:"resource_group,omitempty"`
+
+	//VPCID to find out the subnet-id for ENI
+	VPCID string `json:"vpc_id,omitempty"`
+}
+
+// SecurityGroupRequest used for fetching the securityGroup for volume access point
+type SecurityGroupRequest struct {
+
+	//Name to find out the cluster SG for ENI
+	Name string `json:"name,omitempty"`
+
+	//ResourceGroup to find out the cluster SG for ENI
+	ResourceGroup *ResourceGroup `json:"resource_group,omitempty"`
+
+	//VPCID to find out the cluster SG for ENI
+	VPCID string `json:"vpc_id,omitempty"`
 }

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/vpc_data_types.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/lib/provider/vpc_data_types.go
@@ -40,6 +40,10 @@ type VPCBlockVolume struct {
 type VPCFileVolume struct {
 	VolumeAccessPoints *[]VolumeAccessPoint `json:"volume_access_points,omitempty"`
 	InitialOwner       *InitialOwner        `json:"initial_owner,omitempty"`
+	AccessControlMode  string               `json:"access_control_mode,omitempty"`
+	SecurityGroups     *[]SecurityGroup     `json:"security_groups,omitempty"`
+	PrimaryIP          *PrimaryIP           `json:"primary_ip,omitempty"`
+	SubnetID           string               `json:"subnet_id,omitempty"`
 }
 
 // VPC ...
@@ -48,6 +52,32 @@ type VPC struct {
 	CRN  string `json:"crn,omitempty"`
 	Href string `json:"href,omitempty"`
 	Name string `json:"name,omitempty"`
+}
+
+// SecurityGroup ...
+type SecurityGroup struct {
+	ID   string `json:"id"`
+	CRN  string `json:"crn,omitempty"`
+	Href string `json:"href,omitempty"`
+}
+
+// PrimaryIPID ...
+type PrimaryIPID struct {
+	ID   string `json:"id,omitempty"`
+	Href string `json:"href,omitempty"`
+}
+
+// PrimaryIPAddress ...
+type PrimaryIPAddress struct {
+	Address    string `json:"address,omitempty"`
+	AutoDelete bool   `json:"auto_delete,omitempty"`
+	Name       string `json:"name,omitempty"`
+}
+
+// PrimaryIP ...
+type PrimaryIP struct {
+	PrimaryIPID
+	PrimaryIPAddress
 }
 
 // VolumeAccessPoint ...
@@ -115,7 +145,7 @@ type VolumeEncryptionKey struct {
 	CRN string `json:"crn,omitempty"`
 }
 
-//IKSVolumeAttachment  encapulates IKS related attachment parameters
+// IKSVolumeAttachment  encapulates IKS related attachment parameters
 type IKSVolumeAttachment struct {
 	ClusterID *string `json:"clusterID,omitempty"`
 }

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/lib/utils/error_utils.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/lib/utils/error_utils.go
@@ -132,14 +132,14 @@ func ZapError(err error) zapcore.Field {
 	return zap.Error(err)
 }
 
-//ErrorRetrier retry the function
+// ErrorRetrier retry the function
 type ErrorRetrier struct {
 	MaxAttempts   int
 	RetryInterval time.Duration
 	Logger        *zap.Logger
 }
 
-//NewErrorRetrier return new ErrorRetrier
+// NewErrorRetrier return new ErrorRetrier
 func NewErrorRetrier(maxAttempt int, retryInterval time.Duration, logger *zap.Logger) *ErrorRetrier {
 	return &ErrorRetrier{
 		MaxAttempts:   maxAttempt,
@@ -148,7 +148,7 @@ func NewErrorRetrier(maxAttempt int, retryInterval time.Duration, logger *zap.Lo
 	}
 }
 
-//ErrorRetry path for retry logic with logger passed in
+// ErrorRetry path for retry logic with logger passed in
 func (er *ErrorRetrier) ErrorRetry(funcToRetry func() (error, bool)) error {
 	var err error
 	var shouldStop bool

--- a/vendor/github.com/IBM/ibmcloud-volume-interface/provider/local/provider.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-interface/provider/local/provider.go
@@ -25,6 +25,7 @@ import (
 )
 
 // Provider describes the contract that is implemented by an internal provider implementation
+//
 //go:generate counterfeiter -o fakes/provider.go  --fake-name Provider . Provider
 type Provider interface {
 	// OpenSession begins and initialises a new provider session.
@@ -38,6 +39,7 @@ type Provider interface {
 }
 
 // ContextCredentialsFactory is a factory which can generate ContextCredentials instances
+//
 //go:generate counterfeiter -o fakes/context_credentials_factory.go --fake-name ContextCredentialsFactory . ContextCredentialsFactory
 type ContextCredentialsFactory interface {
 	// ForIaaSAPIKey returns a config using an explicit API key for an IaaS user account

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/IBM/ibm-csi-common/pkg/metrics
 github.com/IBM/ibm-csi-common/pkg/mountmanager
 github.com/IBM/ibm-csi-common/pkg/utils
 github.com/IBM/ibm-csi-common/pkg/watcher
-# github.com/IBM/ibmcloud-volume-interface v1.1.4
+# github.com/IBM/ibmcloud-volume-interface v1.2.0
 ## explicit; go 1.18
 github.com/IBM/ibmcloud-volume-interface/config
 github.com/IBM/ibmcloud-volume-interface/lib/metrics


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-18105

@duanwei33 found that the driver is still not using the proxy after setting the environment variables in https://github.com/openshift/ibm-vpc-block-csi-driver-operator/pull/74

I see a problem with the way the HTTP transport is created, looks like we should be setting the Proxy field with `http.ProxyFromEnvironment` if the CSI driver is to honor the proxy settings.

The code is in https://github.com/IBM/ibmcloud-volume-interface so if this fix is proven to work, then we'll need to get it upstream, and then bump the library.
