### PR TITLE
OCPBUGS-39556: Fix error print in

### DIFF
--- a/pkg/ibmcsidriver/controller_test.go
+++ b/pkg/ibmcsidriver/controller_test.go
@@ -368,7 +368,7 @@ func TestCreateVolumeArguments(t *testing.T) {
 			for i := 0; i < len(vol.GetAccessibleTopology()); i++ {
 				errStr = errStr + fmt.Sprintf("Actual topology-> %#v\nExpected toplogy-> %#v\n\n", vol.GetAccessibleTopology()[i], tc.expVol.GetAccessibleTopology()[i])
 			}
-			t.Errorf(errStr)
+			t.Error(errStr)
 		}
 	}
 }


### PR DESCRIPTION
Fixes CI error print

Part of https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/pull/190

@openshift/storage 