### PR TITLE
OCPBUGS-58369: Updating ose-ibm-vpc-block-csi-driver-container image to be consistent with ART for 4.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.20

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/ibm-vpc-block-csi-driver
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=builder /go/bin/ibm-vpc-block-csi-driver /bin/ibm-vpc-block-csi-driver
 RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates udev && yum clean all && rm -rf /var/cache/yum
 

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 set -euo pipefail
-LINT_VERSION=v1.60.1
+LINT_VERSION=v1.64.8
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${LINT_VERSION}
 if [[ -z "$(command -v golangci-lint)" ]]; then
   echo "Cannot find golangci-lint. Installing golangci-lint..."


### PR DESCRIPTION
Fix `verify` job for https://github.com/openshift/ibm-vpc-block-csi-driver/pull/103