### PR TITLE
OCPBUGS-77214: [release-4.12] standardize build paths

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -4,7 +4,7 @@ COPY . .
 RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.12:base
-COPY --from=builder /go/bin/ibm-vpc-block-csi-driver /bin/ibm-vpc-block-csi-driver
+COPY --from=builder /go/src/github.com/openshift/ibm-vpc-block-csi-driver/bin/ibm-vpc-block-csi-driver /bin/ibm-vpc-block-csi-driver
 RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates udev && yum clean all && rm -rf /var/cache/yum
 
 LABEL description="IBM VPC Block CSI Driver"

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ lint:
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=vendor -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o ${GOPATH}/bin/${EXE_DRIVER_NAME} ./cmd/
+# OpenShift: <carry>: do not write the binary to ${GOPATH}, it's not stable in the builder.
+	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=vendor -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o bin/${EXE_DRIVER_NAME} ./cmd/
 
 .PHONY: verify
 verify:


### PR DESCRIPTION
## Summary
Backport of commit cf951168 from master to release-4.12. Replaces absolute GOPATH-dependent output paths with relative bin/ paths in Makefile.

## Problem
**Before:** Build system rewrites $GOPATH causing non-deterministic build failures due to absolute paths

**After:** Uses relative bin/ paths making builds hermetic-compatible with consistent binary placement