### PR TITLE
NO-JIRA: standardize build paths

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -4,7 +4,7 @@ COPY . .
 RUN make build
 
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
-COPY --from=builder /go/bin/ibm-vpc-block-csi-driver /bin/ibm-vpc-block-csi-driver
+COPY --from=builder /go/src/github.com/openshift/ibm-vpc-block-csi-driver/bin/ibm-vpc-block-csi-driver /bin/ibm-vpc-block-csi-driver
 RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates udev && yum clean all && rm -rf /var/cache/yum
 
 LABEL description="IBM VPC Block CSI Driver"

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ lint: deps
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o ${GOPATH}/bin/${EXE_DRIVER_NAME} ./cmd/
+# OpenShift: <carry>: do not write the binary to ${GOPATH}, it's not stable in the builder.
+	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=vendor -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o bin/${EXE_DRIVER_NAME} ./cmd/
 
 .PHONY: buildmac
 buildmac:


### PR DESCRIPTION
In the latest rebase https://github.com/openshift/ibm-vpc-block-csi-driver/pull/154 I missed the carry patch from https://github.com/openshift/ibm-vpc-block-csi-driver/pull/117 and this causes [build failures](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/logs?nvr=ose-ibm-vpc-block-csi-driver-container-v5.0.0-202607271307.p2.g970918e.assembly.stream.el9&record_id=2349ee4c-340a-d220-c926-f4296d672c1b&group=openshift-5.0) in the ART pipeline. This PR re-introduces the carry patch to fix the build failures.

`Replace absolute GOPATH-dependent output paths with relative bin/ paths in Makefile. The build system rewrites $GOPATH causing non-deterministic build failures when using -o ${GOPATH}/bin/${EXE_DRIVER_NAME}. This differs from other CSI drivers like aws-ebs-csi-driver which use relative paths. The fix ensures consistent binary placement regardless of GOPATH manipulation by the build environment, making builds hermetic-compatible.`

/cc @openshift/storage @fgallott


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenShift builds by placing compiled binaries in the expected location.
  * Added support for automatically detecting the target operating system and architecture during builds.
  * Updated container packaging to correctly include the generated driver binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->